### PR TITLE
SdlService に null チェックを追加

### DIFF
--- a/app/src/main/java/com/oec/sdl/vehicle/SdlService.java
+++ b/app/src/main/java/com/oec/sdl/vehicle/SdlService.java
@@ -195,11 +195,16 @@ public class SdlService extends Service {
                             Integer rpm = onVehicleDataNotification.getRpm();
 							VehicleDataEventStatus eventStatus = onVehicleDataNotification.getDriverBraking();
 
-							Log.w("eventStatus.name()",eventStatus.name());
-							//テキストを登録する場合
-							sdlManager.getScreenManager().setTextField1("RPM: " + onVehicleDataNotification.getRpm());
-							//テキストを登録する場合
-							sdlManager.getScreenManager().setTextField2("Brake: " + eventStatus.name());
+							if (eventStatus != null) {
+								Log.w("eventStatus.name()",eventStatus.name());
+								
+								//テキストを登録する場合
+								sdlManager.getScreenManager().setTextField2("Brake: " + eventStatus.name());
+							}
+							if (rpm != null) {
+								//テキストを登録する場合
+								sdlManager.getScreenManager().setTextField1("RPM: " + rpm);
+							}
 
                             sdlManager.getScreenManager().commit(new CompletionListener() {
                                 @Override


### PR DESCRIPTION
RPMだけを更新してEventStatus が null のとき、ログ出力でコケてRPMが反映されないので、nullチェックを追加しました

更新のあったステータスだけを書き換えるようになります